### PR TITLE
feat: Kirby 5 support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,12 +3,16 @@
 
 [*]
 charset = utf-8
-indent_style = space
-indent_size = 2
 end_of_line = lf
-insert_final_newline = true
+indent_style = tab
+indent_size = 2
 trim_trailing_whitespace = true
 
+[*.php]
+indent_size = 4
+insert_final_newline = true
+
 [*.md,*.txt]
+indent_style = space
 trim_trailing_whitespace = false
 insert_final_newline = false

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Kirby Visual Block Selector",
   "license": "MIT",
   "type": "kirby-plugin",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "authors": [
     {
       "name": "JUNO",
@@ -11,6 +11,6 @@
     }
   ],
   "require": {
-    "getkirby/composer-installer": "^1.1"
+    "getkirby/composer-installer": "^1.2"
   }
 }

--- a/index.css
+++ b/index.css
@@ -17,7 +17,8 @@
 
 /* Button */
 .k-block-selector-button {
-  background-color: var(--color-white);
+	--icon-color: var(--color-text);
+	background: var(--item-color-back);
   border-radius: var(--button-rounded);
   font-variant-numeric: tabular-nums;
   box-shadow: var(--shadow);
@@ -51,6 +52,7 @@
 .k-block-selector-button-preview img {
   object-fit: cover;
   aspect-ratio: 16 / 9;
+  border-radius: var(--rounded-sm);
 }
 
 /* Fallback icon */
@@ -73,5 +75,5 @@
   word-wrap: break-word;
   overflow-wrap: break-word;
   padding: 0.625em 0.625em 0.6875em;
-  border-top: 1px solid var(--color-gray-250, #e8e8e8);
+  border-top: 1px solid var(--color-border);
 }

--- a/index.js
+++ b/index.js
@@ -1,161 +1,85 @@
 panel.plugin('junohamburg/visual-block-selector', {
-  created(Vue) {
-    function loadImage(url) {
-      return new Promise(resolve => {
-        const image = new Image();
-        image.onload = resolve.bind(null, image);
-        image.onerror = resolve;
-        image.src = url;
-      });
-    }
+	components: {
+		'k-block-selector': {
+			extends: 'k-block-selector',
+			template: `
+				<k-dialog
+					:cancel-button="false"
+					:size="showVisualBlockSelector ? 'visual' : 'medium'"
+					:submit-button="false"
+					:visible="true"
+					class="k-block-selector"
+					@cancel="$emit('cancel')"
+					@submit="$emit('submit', value)"
+				>
+					<k-headline v-if="headline">
+						{{ headline }}
+					</k-headline>
 
-    const unsubscribe = Vue.$store.subscribeAction(async (action, state) => {
-      // Fetch preview images once, but only if user is logged in
-      if (window.panel.user.id === null) return;
+					<details
+						v-for="(group, groupName) in groups"
+						:key="groupName"
+						:open="group.open"
+					>
+						<summary>{{ group.label }}</summary>
+						<k-navigate
+							v-if="showVisualBlockSelector"
+							class="k-block-types"
+						>
+							<button
+								class="k-block-selector-button"
+								v-for="fieldset in group.fieldsets"
+								:key="fieldset.name"
+								:disabled="disabledFieldsets.includes(fieldset.type)"
+								:aria-disabled="disabledFieldsets.includes(fieldset.type)"
+								@click="$emit('submit', fieldset.type)"
+								@focus.native="$emit('input', fieldset.type)"
+							>
+								<span class="k-block-selector-button-preview">
+									<img v-if="fieldset.preview" :src="fieldset.preview" alt="" />
+									<k-icon v-else :type="fieldset.icon || 'box'" />
+								</span>
+								<span class="k-block-selector-button-text">{{ fieldset.name }}</span>
+							</button>
+						</k-navigate>
 
-      unsubscribe();
+						<k-navigate
+							v-else
+							class="k-block-types"
+						>
+							<k-button
+								v-for="fieldset in group.fieldsets"
+								:key="fieldset.name"
+								:disabled="disabledFieldsets.includes(fieldset.type)"
+								:icon="fieldset.icon ?? 'box'"
+								:text="fieldset.name"
+								size="lg"
+								@click="$emit('submit', fieldset.type)"
+								@focus.native="$emit('input', fieldset.type)"
+							/>
+						</k-navigate>
+					</details>
+					<!-- eslint-disable vue/no-v-html -->
+					<p
+						class="k-clipboard-hint"
+						v-html="$t('field.blocks.fieldsets.paste', { shortcut })"
+					/>
+					<!-- eslint-enable -->
+				</k-dialog>
+			`,
+			computed: {
+				showVisualBlockSelector() {
+					for (const group of Object.values(this.groups)) {
+						for (const fieldset of group.fieldsets) {
+							if (fieldset.preview !== null) {
+								return true;
+							}
+						}
+					}
 
-      // Create custom store for block selector
-      Vue.$store.registerModule('visualBlockSelector', {
-        state: () => ({
-          blockTypes: [],
-          images: {}
-        }),
-        mutations: {
-          updateBlockTypes(state, blockTypes) {
-            state.blockTypes = blockTypes;
-          },
-          updateImages(state, images) {
-            state.images = images;
-          }
-        },
-        actions: {
-          updateBlockTypes({ commit }, { blockTypes }) {
-            commit('updateBlockTypes', blockTypes);
-          },
-          updateImages({ commit }, { images }) {
-            commit('updateImages', images);
-          }
-        }
-      });
-
-      const apiResponse = await Vue.$api.get('visual-block-selector');
-      const blockTypes = [];
-      const images = {};
-
-      // Get block types
-      for (const name of Object.keys(apiResponse)) {
-        blockTypes.push(name);
-      }
-
-      // Update store
-      Vue.$store.dispatch({
-        type: 'updateBlockTypes',
-        blockTypes: blockTypes
-      });
-
-      // Load images
-      for (const [name, img] of Object.entries(apiResponse)) {
-        images[name] = await loadImage(img);
-      }
-
-      // Update store
-      Vue.$store.dispatch({
-        type: 'updateImages',
-        images: images
-      });
-    });
-  },
-  components: {
-    'k-block-selector': {
-      extends: 'k-block-selector',
-      template: `
-        <k-dialog
-          :cancel-button="false"
-          :size="showVisualBlockSelector ? 'visual' : 'medium'"
-          :submit-button="false"
-          :visible="true"
-          class="k-block-selector"
-          @cancel="$emit('cancel')"
-          @submit="$emit('submit', value)"
-        >
-          <k-headline v-if="headline">
-            {{ headline }}
-          </k-headline>
-
-          <details
-            v-for="(group, groupName) in groups"
-            :key="groupName"
-            :open="group.open"
-          >
-            <summary>{{ group.label }}</summary>
-            <k-navigate
-              v-if="showVisualBlockSelector"
-              class="k-block-types"
-            >
-              <button
-                class="k-block-selector-button"
-                v-for="fieldset in group.fieldsets"
-                :key="fieldset.name"
-                :disabled="disabledFieldsets.includes(fieldset.type)"
-                :aria-disabled="disabledFieldsets.includes(fieldset.type)"
-                @click="$emit('submit', fieldset.type)"
-                @focus.native="$emit('input', fieldset.type)"
-              >
-                <span class="k-block-selector-button-preview">
-                  <img v-if="previewImages[fieldset.type]" :src="previewImages[fieldset.type].src" alt="" />
-                  <k-icon v-else :type="fieldset.icon || 'box'" />
-                </span>
-                <span class="k-block-selector-button-text">{{ fieldset.name }}</span>
-              </button>
-            </k-navigate>
-
-            <k-navigate
-              v-else
-              class="k-block-types"
-            >
-              <k-button
-                v-for="fieldset in group.fieldsets"
-                :key="fieldset.name"
-                :disabled="disabledFieldsets.includes(fieldset.type)"
-                :icon="fieldset.icon ?? 'box'"
-                :text="fieldset.name"
-                size="lg"
-                @click="$emit('submit', fieldset.type)"
-                @focus.native="$emit('input', fieldset.type)"
-              />
-            </k-navigate>
-          </details>
-          <!-- eslint-disable vue/no-v-html -->
-          <p
-            class="k-clipboard-hint"
-            v-html="$t('field.blocks.fieldsets.paste', { shortcut })"
-          />
-          <!-- eslint-enable -->
-        </k-dialog>
-      `,
-      computed: {
-        previewImages() {
-          return this.$store.state.visualBlockSelector.images;
-        },
-        showVisualBlockSelector() {
-          let showVisualBlockSelector = false;
-
-          for (const group of Object.values(this.groups)) {
-            for (const fieldset of group.fieldsets) {
-              if (
-                this.$store.state.visualBlockSelector.blockTypes.includes(
-                  fieldset.type
-                )
-              ) {
-                showVisualBlockSelector = true;
-              }
-            }
-          }
-
-          return showVisualBlockSelector;
-        }
-      }
-    }
-  }
+					return false;
+				}
+			}
+		}
+	}
 });

--- a/index.php
+++ b/index.php
@@ -5,7 +5,7 @@ use Composer\Semver\Semver;
 
 // Validate Kirby version
 if (Semver::satisfies(Kirby::version() ?? '0.0.0', '~4.0 || ~5.0') === false) {
-	throw new Exception('The visual block selector plugin requires Kirby 4');
+	throw new Exception('The visual block selector plugin requires Kirby 4 or Kirby 5');
 }
 
 // Auto-load the custom BlocksField class

--- a/index.php
+++ b/index.php
@@ -4,7 +4,7 @@ use Kirby\Cms\App as Kirby;
 use Composer\Semver\Semver;
 
 // Validate Kirby version
-if (Semver::satisfies(Kirby::version() ?? '0.0.0', '~4.0') === false) {
+if (Semver::satisfies(Kirby::version() ?? '0.0.0', '~4.0 || ~5.0') === false) {
   throw new Exception('The visual block selector plugin requires Kirby 4');
 }
 

--- a/index.php
+++ b/index.php
@@ -5,30 +5,16 @@ use Composer\Semver\Semver;
 
 // Validate Kirby version
 if (Semver::satisfies(Kirby::version() ?? '0.0.0', '~4.0 || ~5.0') === false) {
-  throw new Exception('The visual block selector plugin requires Kirby 4');
+	throw new Exception('The visual block selector plugin requires Kirby 4');
 }
 
+// Auto-load the custom BlocksField class
+load([
+	'JunoHamburg\VisualBlockSelector\BlocksField' => __DIR__ . '/src/BlocksField.php',
+]);
+
 Kirby::plugin('junohamburg/visual-block-selector', [
-  'api' => [
-    'routes' => [
-      [
-        'pattern' => 'visual-block-selector',
-        'action'  => function () {
-          $previewImages = [];
-          $dir = 'block-previews';
-          $path = kirby()->root('assets') . '/' . $dir;
-          $imageFiles = Dir::files($path);
-
-          $relativePath = str_replace(kirby()->root('index') . '/', '', kirby()->root('assets'));
-
-          foreach ($imageFiles as $image) {
-            $imageAsset = asset($relativePath . '/' . $dir . '/' . $image);
-            $previewImages[$imageAsset->name()] = $imageAsset->url();
-          }
-
-          return $previewImages;
-        }
-      ]
-    ]
-  ]
+	'fields' => [
+		'blocks' => 'JunoHamburg\VisualBlockSelector\BlocksField'
+	],
 ]);

--- a/src/BlocksField.php
+++ b/src/BlocksField.php
@@ -44,11 +44,12 @@ class BlocksField extends KirbyBlocksField
 		$props    = parent::props();
 		$previews = $this->previews();
 
-		$props['fieldsets'] = array_map(function (array $fieldset) use ($previews) {
-			$fieldset['preview'] = $previews[$fieldset['type']] ?? null;
-			return $fieldset;
-		}, $props['fieldsets']);
-
-		return $props;
+        return [
+			...$props,
+			'fieldsets' => array_map(fn (array $fieldset) => [
+				...$fieldset,
+				'preview' => $previews[$fieldset['type']] ?? null
+			], $props['fieldsets'])
+		];
 	}
 }

--- a/src/BlocksField.php
+++ b/src/BlocksField.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace JunoHamburg\VisualBlockSelector;
+
+use Kirby\Filesystem\Dir;
+use Kirby\Form\Field\BlocksField as KirbyBlocksField;
+
+/**
+ * Custom BlocksField class, which provides the
+ * visual block selector component with preview images.
+ */
+class BlocksField extends KirbyBlocksField
+{
+	/**
+	 * Collects all block preview images
+	 * in the assets directory
+	 *
+	 * @return array<string, string>
+	 */
+	protected function previews(): array
+	{
+		$kirby    = kirby();
+		$previews = [];
+		$dir      = 'block-previews';
+		$path     = $kirby->root('assets') . '/' . $dir;
+		$images   = Dir::files($path);
+
+		$relativePath = str_replace($kirby->root('index') . '/', '', $kirby->root('assets'));
+
+		foreach ($images as $image) {
+			$asset = asset($relativePath . '/' . $dir . '/' . $image);
+			$previews[$asset->name()] = $asset->url();
+		}
+
+		return $previews;
+	}
+
+	/**
+	 * Adds the preview images to the fieldsets
+	 * if they exist
+	 */
+	public function props(): array
+	{
+		$props    = parent::props();
+		$previews = $this->previews();
+
+		$props['fieldsets'] = array_map(function (array $fieldset) use ($previews) {
+			$fieldset['preview'] = $previews[$fieldset['type']] ?? null;
+			return $fieldset;
+		}, $props['fieldsets']);
+
+		return $props;
+	}
+}

--- a/src/BlocksField.php
+++ b/src/BlocksField.php
@@ -19,7 +19,7 @@ class BlocksField extends KirbyBlocksField
 	 */
 	protected function previews(): array
 	{
-		$kirby    = kirby();
+		$kirby    = $this->kirby();
 		$previews = [];
 		$dir      = 'block-previews';
 		$path     = $kirby->root('assets') . '/' . $dir;


### PR DESCRIPTION
Sorry for competing with @tobimori's PR here :)

## Changelog

### Enhancement

- New custom `JunoHamburg\VisualBlockSelector\BlocksField` class that extends the `Kirby\Form\Field\BlocksField`. We can use this to add the preview images directly in the backend code and pass them together with the other fieldset props. 
- Removed the API endpoint, which is no longer needed
- Removed the additional JS code in the custom component to load the previews from the backend. The custom block selector component is now a lot simpler. 

### Fix 

- Support 5.0.0+ in index.php
- CSS adjustments to support dark mode

### Housekeeping

- Use tabs instead of spaces for indentation to follow Kirby defaults
- Bump version number to 3.0.0 (you should to decide if you want turn this into a 3.0 or a 2.2) and the getkirby/composer-installer to 1.2 